### PR TITLE
increased grpc call size

### DIFF
--- a/node/remote/utils.go
+++ b/node/remote/utils.go
@@ -44,6 +44,10 @@ func CreateGrpcConnection(cfg *GRPCConfig) (*grpc.ClientConn, error) {
 		grpcOpts = append(grpcOpts, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
 	}
 
+	// Set the max message size to 20MB
+	maxMsgSize := 1024 * 1024 * 20
+	grpcOpts = append(grpcOpts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize), grpc.MaxCallSendMsgSize(maxMsgSize)))
+
 	address := HTTPProtocols.ReplaceAllString(cfg.Address, "")
 	return grpc.Dial(address, grpcOpts...)
 }


### PR DESCRIPTION
## Description
Rose the GRPC call size in order to not fail when huge TX occurs.
